### PR TITLE
global: nharraud added as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,3 @@
 Jiri Kuncar <jiri.kuncar@cern.ch> (@jirikuncar)
 Lars Holm Nielsen <lars.holm.nielsen@cern.ch> (@lnielsen)
+Nicolas Harraudeau <nicolas.harraudeau@cern.ch> (@nharraud)


### PR DESCRIPTION
Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>