### PR TITLE
Loaders serializers refactor

### DIFF
--- a/invenio_accounts_rest/serializers.py
+++ b/invenio_accounts_rest/serializers.py
@@ -24,7 +24,7 @@
 
 """Invenio accounts REST module's serializers."""
 
-from flask import jsonify, url_for
+from flask import Response, jsonify, url_for
 
 
 def role_to_dict(role):
@@ -98,17 +98,15 @@ def roles_list_serializer(roles, code=200, headers=None, links=None,
     return response
 
 
-def status_code_serializer(code, headers=None):
-    """Serialize a status code to json response.
+def status_code_serializer(code=200, headers=None):
+    """Create a response without any content.
 
     :param code: http response code.
     :param headers: additional http response headers.
     :return: response from api.
     :rtype: Response
     """
-    response = jsonify({
-        'code': code,
-    })
+    response = Response()
     response.status_code = code
     if headers is not None:
         response.headers.extend(headers)

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test default data loader."""
+
+import pytest
+from invenio_accounts.models import Role, User
+from invenio_rest.errors import RESTValidationError
+from werkzeug.exceptions import BadRequest
+
+from invenio_accounts_rest.errors import PatchJSONFailureRESTError
+from invenio_accounts_rest.loaders import account_json_patch_loader_factory, \
+    default_role_json_patch_loader
+
+
+def subtest_json_patch_loader(app, loader, input_, known_field):
+    # test invalid field
+    with app.test_request_context('', data='[{"op": "replace", '
+                                  '"path": "/unknown", "value": "v"}]'):
+        with pytest.raises(RESTValidationError):
+            loader(input_)
+
+    # test invalid JSON PATCH
+    with app.test_request_context('', data='[{"op": "replace", '
+                                  '"path": "/' + known_field + '"}]'):
+        with pytest.raises(PatchJSONFailureRESTError):
+            loader(input_)
+
+    # test without data
+    with app.test_request_context(''):
+        with pytest.raises(BadRequest):
+            loader(input_)
+
+
+def test_account_json_patch_loader_factory_errors(app, users):
+    """Test account_json_patch_loader_factory error handling."""
+    valid_fields = ['field_A', 'field_B']
+    loader = account_json_patch_loader_factory(valid_fields)
+    with app.app_context():
+        user = User.query.filter(User.id == users['user1'].id).one()
+        subtest_json_patch_loader(app, loader, user, 'field_A')
+
+
+def test_default_role_json_patch_loader_errors(app, create_roles):
+    """Test default_role_json_patch_loader error handling."""
+    with app.app_context():
+        role = Role.query.filter(Role.id == create_roles[0]['id']).one()
+        subtest_json_patch_loader(app, default_role_json_patch_loader, role,
+                                  'name')


### PR DESCRIPTION
views: loaders and serializers refactoring
* FIX Splits ACCOUNTS_REST_ACCOUNT_SERIALIZERS config variable used
  in UserListResource and UserAccountResource as two separate config
  variables. (closes #19)

* FIX Removes content from code 204 responses. (closes #22)

* BETTER Adds config variables for overriding roles serializers.
  (closes #20)

* BETTER Adds roles loaders and config variable to override
  them. (closes #21)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>